### PR TITLE
Replaced 'canonical_section_number' with 'number' in solve_section()

### DIFF
--- a/ZybookAuto.py
+++ b/ZybookAuto.py
@@ -112,8 +112,20 @@ def solve_part(act_id, sec_id, auth, part, code):
 
 # Solves all problems in given section
 def solve_section(section, code, chapter, auth):
+    sec_name = str(chapter["number"]) + "." + str(section["number"])
+    print("Starting section", sec_name)
     sec_id = section["canonical_section_id"]
-    problems = get_problems(code, chapter["number"], section["canonical_section_number"], auth)
+    try:
+        problems = get_problems(code, chapter["number"], section["number"], auth)
+    except KeyError as e:
+        print("Failed solving", sec_name)
+        print(str(e), "is missing, retrying with canonical section number...")
+        try:
+            problems = get_problems(code, chapter["number"], section["canonical_section_number"], auth)
+            pass
+        except KeyError:
+            print("Failed solving", str(chapter["number"]) + "." + str(section["canonical_section_number"]))
+            return
     p = 1
     for problem in problems:
         act_id = problem["id"]


### PR DESCRIPTION
I couldn't find any documentation as to why one was chosen over the other but as other users reported `canonical_section_number` is causing KeyError's with some chapters. At least in my testing a direct swapping of them has worked flawlessly in comparison, but I was sure to add a fallback in cases where using `number` failed. 

Error I was getting before for documentation's sake:
```
Traceback (most recent call last):
  File "C:\Users\Foo\Documents\Programming\zybooks\ZybookAuto\ZybookAuto.py", line 266, in <module>
    main()
  File "C:\Users\Foo\Documents\Programming\zybooks\ZybookAuto\ZybookAuto.py", line 210, in main
    solve_section(section, code, chapter, auth)
  File "C:\Users\Foo\Documents\Programming\zybooks\ZybookAuto\ZybookAuto.py", line 117, in solve_section
    problems = get_problems(code, chapter["number"], section["canonical_section_number"], auth)
  File "C:\Users\Foo\Documents\Programming\zybooks\ZybookAuto\ZybookAuto.py", line 41, in get_problems
    return problems["section"]["content_resources"]
KeyError: 'section'
```